### PR TITLE
Added an onreconnect method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ class ReconnectableWebSocket {
     this._options = Object.assign({}, defaultOptions, options)
     this._messageQueue = []
     this._reconnectAttempts = 0
+    this._isReconnecting = false
     this.readyState = this.CONNECTING
 
     if (options.automaticOpen) this.open()
@@ -68,6 +69,11 @@ class ReconnectableWebSocket {
     this._reconnectAttempts = 0
 
     this.onopen && this.onopen(event)
+
+    if (this._isReconnecting) {
+      this._isReconnecting = false
+      this.onreconnect && this.onreconnect()
+    }
   };
 
   _onclose = (event) => {
@@ -92,14 +98,13 @@ class ReconnectableWebSocket {
   };
 
   _tryReconnect = (event) => {
-    if (!event.wasClean) {
-      setTimeout(() => {
-        if (this.readyState === this.CLOSED) {
-          this._reconnectAttempts++
-          this.open()
-        }
-      }, this._getTimeout())
-    }
+    this._isReconnecting = true
+    setTimeout(() => {
+      if (this.readyState === this.CLOSED) {
+        this._reconnectAttempts++
+        this.open()
+      }
+    }, this._getTimeout())
   };
 
   _flushQueue = () => {


### PR DESCRIPTION
We are using this to listen on a channel, so when we connect we need to emit something like `join <channel>`.  This feature enabled re-joining on reconnect for us.  But it could be used for many other use cases.

NOTE: it removed the check for `event.wasClean` because a clean server restart requires a disconnect and re-connect.  I would be interested in hearing the original reasoning for only trying the reconnect on error close cases/not clean shutdowns.  Also if I had a test case for it I could make sure it is still supported.
